### PR TITLE
Add ActivateCredentialStarted and ActivateCredentialCompleted events, deprecate ForgotPasswordEmailSent and ForgotPasswordReset

### DIFF
--- a/src/main/java/com/tenduke/events/api/model/object/ActivateCredentialCompleted.java
+++ b/src/main/java/com/tenduke/events/api/model/object/ActivateCredentialCompleted.java
@@ -1,0 +1,47 @@
+package com.tenduke.events.api.model.object;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.tenduke.events.api.model.data.ErrorInfoFields;
+import com.tenduke.events.api.model.data.RequestFields;
+import com.tenduke.events.api.model.data.TimeFields;
+import com.tenduke.events.api.model.data.UserIdFields;
+
+/**
+ * Process for activating a new credential completed. For example, user has set
+ * up a new password ("forgot password" process), or user has activated a new
+ * user account by setting up a passkey.
+ * @author jarkko
+ * @since 10Duke Enterprise 6.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface ActivateCredentialCompleted extends
+        TimeFields,
+        RequestFields,
+        ErrorInfoFields,
+        UserIdFields {
+
+    /**
+     * Activating a new password has been started by delivering a code to the
+     * user ("forgot password" process, code usually sent by email).
+     */
+    String CREDENTIAL_ACTIVATION_PROCESS_RESET_PASSWORD =
+            ActivateCredentialStarted.CREDENTIAL_ACTIVATION_PROCESS_RESET_PASSWORD;
+
+    /**
+     * Activating user account has been started by delivering a code to the
+     * user (usually by email). The user may activate the account by setting
+     * up any credentials allowed in the system, for example a password or
+     * a passkey.
+     */
+    String CREDENTIAL_ACTIVATION_PROCESS_ACTIVATE_USER =
+            ActivateCredentialStarted.CREDENTIAL_ACTIVATION_PROCESS_ACTIVATE_USER;
+
+    /**
+     * Gets name of the credential activation process.
+     * @return The activation process name, one of the
+     *      <code>CREDENTIAL_ACTIVATION_PROCESS_</code> values declared by this
+     *      interface, or a custom value if a customized activation process is
+     *      used.
+     */
+    String getActivationProcess();
+}

--- a/src/main/java/com/tenduke/events/api/model/object/ActivateCredentialStarted.java
+++ b/src/main/java/com/tenduke/events/api/model/object/ActivateCredentialStarted.java
@@ -1,0 +1,48 @@
+package com.tenduke.events.api.model.object;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.tenduke.events.api.model.data.ErrorInfoFields;
+import com.tenduke.events.api.model.data.RequestFields;
+import com.tenduke.events.api.model.data.TimeFields;
+import com.tenduke.events.api.model.data.UserIdFields;
+import com.tenduke.events.api.model.data.ValidityFields;
+
+/**
+ * Process for activating a new credential started. Examples of cases when new
+ * credential activation is started are sending email to reset password (end
+ * user self-service) or sending email to user for setting up a passkey or
+ * password after their organization has initialized their data in the system.
+ * @author jarkko
+ * @since 10Duke Enterprise 6.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface ActivateCredentialStarted extends
+        TimeFields,
+        RequestFields,
+        ErrorInfoFields,
+        UserIdFields,
+        ValidityFields {
+
+    /**
+     * Activating a new password has been started by delivering a code to the
+     * user ("forgot password" process, code usually sent by email).
+     */
+    String CREDENTIAL_ACTIVATION_PROCESS_RESET_PASSWORD = "ResetPassword";
+
+    /**
+     * Activating user account has been started by delivering a code to the
+     * user (usually by email). The user may activate the account by setting
+     * up any credentials allowed in the system, for example a password or
+     * a passkey.
+     */
+    String CREDENTIAL_ACTIVATION_PROCESS_ACTIVATE_USER = "ActivateUser";
+
+    /**
+     * Gets name of the credential activation process.
+     * @return The activation process name, one of the
+     *      <code>CREDENTIAL_ACTIVATION_PROCESS_</code> values declared by this
+     *      interface, or a custom value if a customized activation process is
+     *      used.
+     */
+    String getActivationProcess();
+}

--- a/src/main/java/com/tenduke/events/api/model/object/ForgotPasswordEmailSent.java
+++ b/src/main/java/com/tenduke/events/api/model/object/ForgotPasswordEmailSent.java
@@ -10,7 +10,10 @@ import com.tenduke.events.api.model.data.ValidityFields;
 /**
  * Email sent to user for the purpose of resetting password (forgot password).
  * @author jarkko
+ * @deprecated Replaced by {@link ActivateCredentialStarted} that can describe
+ *      all credential activation cases.
  */
+@Deprecated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface ForgotPasswordEmailSent extends
         TimeFields,

--- a/src/main/java/com/tenduke/events/api/model/object/ForgotPasswordReset.java
+++ b/src/main/java/com/tenduke/events/api/model/object/ForgotPasswordReset.java
@@ -9,7 +9,10 @@ import com.tenduke.events.api.model.data.UserIdFields;
 /**
  * User has reset her password (forgot password).
  * @author jarkko
+ * @deprecated Replaced by {@link ActivateCredentialCompleted} that can describe
+ *      all credential activation cases.
  */
+@Deprecated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface ForgotPasswordReset extends
         TimeFields,

--- a/src/test/java/com/tenduke/events/api/model/object/PrintEventObjectFieldsTest.java
+++ b/src/test/java/com/tenduke/events/api/model/object/PrintEventObjectFieldsTest.java
@@ -44,6 +44,8 @@ public class PrintEventObjectFieldsTest {
      * Event data objects related to user actions.
      */
     private static final List<Class<?>> USER_ACTION_OBJS = Arrays.asList(
+            ActivateCredentialCompleted.class,
+            ActivateCredentialStarted.class,
             ForgotPasswordEmailSent.class,
             ForgotPasswordReset.class,
             OrganizationInvitationAccepted.class,


### PR DESCRIPTION
Closes #22 

Add ActivateCredentialStarted and ActivateCredentialCompleted events, deprecate ForgotPasswordEmailSent and ForgotPasswordReset. This is needed to correctly describe cases for account activation and for passkeys.