### PR TITLE
Use own specific resource file instead of manifest.mf for reading artifact version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,25 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>
+
+        <resources>
+            <!-- Enable filtering resources in META-INF/10duke -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>META-INF/10duke/*</include>
+                </includes>
+            </resource>
+            <!-- Do not use filtering elsewhere -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>META-INF/10duke/*</exclude>
+                </excludes>
+            </resource>
+        </resources>
     </build>
 
     <profiles>

--- a/src/main/java/com/tenduke/events/api/model/EventApi.java
+++ b/src/main/java/com/tenduke/events/api/model/EventApi.java
@@ -1,10 +1,26 @@
 package com.tenduke.events.api.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
 /**
  * Metadata of the 10Duke Event Data model described by this artifact.
  * @author jarkko
  */
 public final class EventApi {
+
+    /**
+     * Name of resource containing events-api properties.
+     */
+    private static final String EVENTS_API_PROPERTIES_RESOURCE = "/META-INF/10duke/events-api.properties";
+
+    /**
+     * Version of the event-api artifact.
+     */
+    private static String version;
 
     /**
      * Prevents an instance of the {@link EventApi} class from being created.
@@ -18,6 +34,24 @@ public final class EventApi {
      * @return The API version.
      */
     public static final String getApiVersion() {
-        return EventApi.class.getPackage().getImplementationVersion();
+        if (version != null) {
+            return version;
+        }
+
+        // Earlier version was read from Manifest.mf using EventApi.class.getPackage().getImplementationVersion().
+        // That didn't work correctly, classloader seemed to mess up between different webapps.
+        try (final InputStream resourceStream = EventApi.class.getClassLoader()
+                .getResourceAsStream(EVENTS_API_PROPERTIES_RESOURCE)) {
+            try (final InputStreamReader reader = new InputStreamReader(resourceStream, StandardCharsets.UTF_8)) {
+                final Properties props = new Properties();
+                props.load(reader);
+                final String versionProperty = props.getProperty("version");
+                version = versionProperty;
+                return versionProperty;
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Reading events-api version from embedded resource failed", ex);
+        }
     }
+
 }

--- a/src/main/resources/META-INF/10duke/events-api.properties
+++ b/src/main/resources/META-INF/10duke/events-api.properties
@@ -1,0 +1,1 @@
+version=${project.version}


### PR DESCRIPTION
Old way of using EventApi.class.getPackage().getImplementationVersion() stopped working in an app server environment with multiple webapps

Closes #25 